### PR TITLE
fix: show navbar after closing For You player

### DIFF
--- a/app/(tabs)/foryou.tsx
+++ b/app/(tabs)/foryou.tsx
@@ -28,17 +28,25 @@ export default function ForYouScreen() {
     isVisible: false,
     episodes: [],
   });
+  const [hasAutoLaunched, setHasAutoLaunched] = useState(false);
 
   // Auto-launch player when episodes are loaded (web only)
   useEffect(() => {
-    if (Platform.OS === 'web' && !loading && firstEpisodes.length > 0 && !playerState.isVisible) {
+    if (
+      Platform.OS === 'web' &&
+      !loading &&
+      firstEpisodes.length > 0 &&
+      !playerState.isVisible &&
+      !hasAutoLaunched
+    ) {
       console.log('🎬 For You: Auto-launching player with first episodes:', firstEpisodes.length);
       setPlayerState({
         isVisible: true,
         episodes: firstEpisodes,
       });
+      setHasAutoLaunched(true);
     }
-  }, [loading, firstEpisodes, playerState.isVisible]);
+  }, [loading, firstEpisodes, playerState.isVisible, hasAutoLaunched]);
 
   const closePlayer = () => {
     console.log('🎬 For You: Closing player');
@@ -50,17 +58,20 @@ export default function ForYouScreen() {
       });
       window.dispatchEvent(hidePlayerEvent);
     }
-    
+
+    setHasAutoLaunched(true);
+
     // First delay: Allow tab bar to process visibility event
     setTimeout(() => {
       setPlayerState({
         isVisible: false,
         episodes: [],
       });
-      
+
       // Second delay: Ensure UI has settled before navigation
       setTimeout(() => {
-        router.replace('/(tabs)');
+        // Use root path since route groups aren't part of the URL
+        router.replace('/');
       }, 100);
     }, 50);
   };


### PR DESCRIPTION
## Summary
- prevent For You player from relaunching after close
- ensure closing player returns to home tab and re-enables navbar
- redirect For You close action to root path to avoid missing screen

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: TypeError: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_68aef9eac23083268a5dde0b0f19577b