### PR TITLE
fix: show navbar after closing For You player

### DIFF
--- a/app/(tabs)/foryou.tsx
+++ b/app/(tabs)/foryou.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, Image, Dimensions, Alert } from 'react-native';
 import { Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Play, User, Gift } from 'lucide-react-native';
-import { router } from 'expo-router';
+import { router, useFocusEffect } from 'expo-router';
 import { Image as RNImage } from 'react-native';
 import { useFirstEpisodesOfAllSeries } from '@/hooks/useContent';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -28,41 +28,56 @@ export default function ForYouScreen() {
     isVisible: false,
     episodes: [],
   });
+  const [hasAutoLaunched, setHasAutoLaunched] = useState(false);
+
+  // Reset auto-launch when screen gains focus
+  useFocusEffect(
+    useCallback(() => {
+      if (!playerState.isVisible) {
+        setHasAutoLaunched(false);
+      }
+    }, [playerState.isVisible])
+  );
 
   // Auto-launch player when episodes are loaded (web only)
   useEffect(() => {
-    if (Platform.OS === 'web' && !loading && firstEpisodes.length > 0 && !playerState.isVisible) {
+    if (
+      Platform.OS === 'web' &&
+      !loading &&
+      firstEpisodes.length > 0 &&
+      !playerState.isVisible &&
+      !hasAutoLaunched
+    ) {
       console.log('🎬 For You: Auto-launching player with first episodes:', firstEpisodes.length);
       setPlayerState({
         isVisible: true,
         episodes: firstEpisodes,
       });
+      setHasAutoLaunched(true);
     }
-  }, [loading, firstEpisodes, playerState.isVisible]);
+  }, [loading, firstEpisodes, playerState.isVisible, hasAutoLaunched]);
 
   const closePlayer = () => {
     console.log('🎬 For You: Closing player');
-    
-    // Dispatch custom event to show navigation when player closes
-    if (Platform.OS === 'web') {
-      const hidePlayerEvent = new CustomEvent('playerVisibilityChanged', {
-        detail: { isVisible: false }
-      });
-      window.dispatchEvent(hidePlayerEvent);
-    }
-    
-    // First delay: Allow tab bar to process visibility event
+    setHasAutoLaunched(true);
+
+    // Immediately hide the player
+    setPlayerState({
+      isVisible: false,
+      episodes: [],
+    });
+
+    // Navigate home and explicitly restore the navbar after redirect
     setTimeout(() => {
-      setPlayerState({
-        isVisible: false,
-        episodes: [],
-      });
-      
-      // Second delay: Ensure UI has settled before navigation
-      setTimeout(() => {
-        router.replace('/(tabs)');
-      }, 100);
-    }, 50);
+      router.replace('/');
+
+      if (Platform.OS === 'web') {
+        const hidePlayerEvent = new CustomEvent('playerVisibilityChanged', {
+          detail: { isVisible: false }
+        });
+        window.dispatchEvent(hidePlayerEvent);
+      }
+    }, 100);
   };
 
   // Log country information for debugging


### PR DESCRIPTION
## Summary
- explicitly hide For You player and return user to home tab
- dispatch player visibility event after redirect so navbar is restored

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: TypeError: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_68aef9eac23083268a5dde0b0f19577b