### PR TITLE
fix: keep auth inputs enabled

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -21,68 +21,41 @@ export default function LoginScreen() {
 
   // Check biometric support and status on component mount
   React.useEffect(() => {
-    // Check for error message from signup redirect or localStorage
     const checkForErrorMessage = async () => {
-     // Ensure inputs are always enabled when screen loads
-     setIsLoading(false);
-     
+      // Ensure inputs are enabled when screen loads
+      setIsLoading(false);
+
       if (routeErrorMessage) {
         setErrorMessage(routeErrorMessage);
-        // Clear input values when redirected with error
         setEmailOrPhone('');
         setPassword('');
-        
-        // Focus the email input after a short delay to ensure it's interactive
-        setTimeout(() => {
-          emailInputRef.current?.focus();
-        }, 100);
-        // Clear input values when redirected with error
-        setEmailOrPhone('');
-        setPassword('');
-        
-        // Focus the email input after a short delay to ensure it's interactive
-        setTimeout(() => {
-          emailInputRef.current?.focus();
-        }, 100);
+        setTimeout(() => emailInputRef.current?.focus(), 100);
       } else if (Platform.OS === 'web') {
         const storedError = localStorage.getItem('signinErrorMessage');
         if (storedError) {
           setErrorMessage(storedError);
           localStorage.removeItem('signinErrorMessage');
-          // Clear input values when redirected with error
           setEmailOrPhone('');
           setPassword('');
-          
-          // Focus the email input after a short delay to ensure it's interactive
-          setTimeout(() => {
-            emailInputRef.current?.focus();
-          }, 100);
-          // Clear input values when redirected with error
-          setEmailOrPhone('');
-          setPassword('');
-          
-          // Focus the email input after a short delay to ensure it's interactive
-          setTimeout(() => {
-            emailInputRef.current?.focus();
-          }, 100);
+          setTimeout(() => emailInputRef.current?.focus(), 100);
         }
       }
     };
-    
+
     checkForErrorMessage();
-    
+
     const checkBiometrics = async () => {
       if (Platform.OS === 'ios' || Platform.OS === 'android' || Platform.OS === 'web') {
         const support = await checkBiometricSupport();
         setBiometricSupport(support);
-        
+
         if (support.isAvailable) {
           const enabled = await checkIsBiometricEnabled();
           setIsBiometricEnabled(enabled);
         }
       }
     };
-    
+
     checkBiometrics();
   }, []);
   const handleLogin = async () => {
@@ -95,42 +68,46 @@ export default function LoginScreen() {
     }
 
     setIsLoading(true);
-    const success = await login(emailOrPhone, password);
-    setIsLoading(false);
-
-    if (success) {
-      router.replace('/(tabs)');
-    } else {
-      setErrorMessage(t('invalidCredentials'));
+    try {
+      const success = await login(emailOrPhone, password);
+      if (success) {
+        router.replace('/(tabs)');
+      } else {
+        setErrorMessage(t('invalidCredentials'));
+      }
+    } finally {
+      setIsLoading(false);
     }
   };
 
   const handleBiometricLogin = async () => {
     setIsLoading(true);
-    const result = await performBiometricLogin();
-    setIsLoading(false);
-
-    if (result.success) {
-      router.replace('/(tabs)');
-    } else {
-      let errorMessage = result.error || t('biometricAuthFailed');
-      
-      // Provide more user-friendly messages for common scenarios
-      if (Platform.OS === 'web') {
-        if (errorMessage.includes('WebAuthn login is not enabled')) {
-         errorMessage = t('webauthnNotEnabled');
-        } else if (errorMessage.includes('Authentication was cancelled')) {
-         errorMessage = t('webauthnCancelled');
-        }
+    try {
+      const result = await performBiometricLogin();
+      if (result.success) {
+        router.replace('/(tabs)');
       } else {
-        if (errorMessage.includes('No stored authentication data found')) {
-         errorMessage = t('biometricNoUserData');
-        } else if (errorMessage.includes('Biometric token not found')) {
-         errorMessage = t('biometricNoUserData');
+        let errorMessage = result.error || t('biometricAuthFailed');
+
+        // Provide more user-friendly messages for common scenarios
+        if (Platform.OS === 'web') {
+          if (errorMessage.includes('WebAuthn login is not enabled')) {
+            errorMessage = t('webauthnNotEnabled');
+          } else if (errorMessage.includes('Authentication was cancelled')) {
+            errorMessage = t('webauthnCancelled');
+          }
+        } else {
+          if (errorMessage.includes('No stored authentication data found')) {
+            errorMessage = t('biometricNoUserData');
+          } else if (errorMessage.includes('Biometric token not found')) {
+            errorMessage = t('biometricNoUserData');
+          }
         }
+
+        Alert.alert(t('error'), errorMessage);
       }
-      
-      Alert.alert(t('error'), errorMessage);
+    } finally {
+      setIsLoading(false);
     }
   };
   
@@ -195,7 +172,6 @@ export default function LoginScreen() {
             <Text style={styles.label}>{t('emailOrPhone')}</Text>
             <TextInput
               ref={emailInputRef}
-              ref={emailInputRef}
               style={styles.input}
               value={emailOrPhone}
               onChangeText={handleEmailOrPhoneChange}
@@ -203,8 +179,6 @@ export default function LoginScreen() {
               placeholderTextColor="#666"
               keyboardType="default"
               autoCapitalize="none"
-              editable={!isLoading}
-              editable={!isLoading}
               textContentType="none"
             />
           </View>
@@ -218,8 +192,6 @@ export default function LoginScreen() {
               placeholder={t('enterPassword')}
               placeholderTextColor="#666"
               secureTextEntry
-              editable={!isLoading}
-              editable={!isLoading}
               textContentType="none"
             />
           </View>

--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -35,9 +35,9 @@ export default function SignupScreen() {
     }
 
     setIsLoading(true);
-    
+
     console.log('🔐 SIGNUP SCREEN DEBUG: About to call signup function');
-    
+
     // Call the signup edge function directly to get more detailed error information
     try {
       const response = await fetch(`${process.env.EXPO_PUBLIC_SUPABASE_URL}/functions/v1/signup`, {
@@ -61,13 +61,13 @@ export default function SignupScreen() {
       if (!response.ok) {
         const errorData = await response.json();
         console.log('🔐 SIGNUP SCREEN DEBUG: Error response data:', JSON.stringify(errorData, null, 2));
-        
+
         // Check for specific error types that need special handling
         if (errorData.errorType === 'EXISTING_USER_INVALID_CREDENTIALS') {
           console.log('🔐 SIGNUP SCREEN DEBUG: EXISTING_USER_INVALID_CREDENTIALS detected, preparing redirect');
           console.log('🔐 SIGNUP SCREEN DEBUG: Platform:', Platform.OS);
           console.log('🔐 SIGNUP SCREEN DEBUG: Error message to store:', t('userExistsInvalidCredentials'));
-          
+
           // Store specific error message for signin page
           if (Platform.OS === 'web') {
             console.log('🔐 SIGNUP SCREEN DEBUG: Web platform - storing error in localStorage');
@@ -90,12 +90,13 @@ export default function SignupScreen() {
         } else {
           console.log('🔐 SIGNUP SCREEN DEBUG: Different error type, setting generic error message');
           setErrorMessage(errorData.error || t('failedToCreateAccount'));
+          return;
         }
       } else {
         // Success case - call the useAuth signup function for state management
         const success = await signup(email, password);
         console.log('🔐 SIGNUP SCREEN DEBUG: Signup function returned:', success);
-        
+
         if (success) {
           console.log('🔐 SIGNUP SCREEN DEBUG: Signup successful, redirecting to tabs');
           router.replace('/(tabs)');
@@ -107,10 +108,10 @@ export default function SignupScreen() {
     } catch (error: any) {
       console.error('🔐 SIGNUP SCREEN DEBUG: Network or other error:', error);
       setErrorMessage(t('failedToCreateAccount'));
+    } finally {
+      console.log('🔐 SIGNUP SCREEN DEBUG: Setting isLoading to false');
+      setIsLoading(false);
     }
-    
-    console.log('🔐 SIGNUP SCREEN DEBUG: Setting isLoading to false');
-    setIsLoading(false);
   };
 
   // Clear error message when user starts typing


### PR DESCRIPTION
## Summary
- ensure login fields stay interactive by dropping isLoading gating
- reset loading state with finally in login and signup handlers to avoid stale disabled inputs

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dc397cc88326866412d891c8f779