### PR TITLE
fix: keep auth inputs enabled

### DIFF
--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -35,9 +35,9 @@ export default function SignupScreen() {
     }
 
     setIsLoading(true);
-    
+
     console.log('🔐 SIGNUP SCREEN DEBUG: About to call signup function');
-    
+
     // Call the signup edge function directly to get more detailed error information
     try {
       const response = await fetch(`${process.env.EXPO_PUBLIC_SUPABASE_URL}/functions/v1/signup`, {
@@ -61,17 +61,18 @@ export default function SignupScreen() {
       if (!response.ok) {
         const errorData = await response.json();
         console.log('🔐 SIGNUP SCREEN DEBUG: Error response data:', JSON.stringify(errorData, null, 2));
-        
+
         // Check for specific error types that need special handling
         if (errorData.errorType === 'EXISTING_USER_INVALID_CREDENTIALS') {
           console.log('🔐 SIGNUP SCREEN DEBUG: EXISTING_USER_INVALID_CREDENTIALS detected, preparing redirect');
           console.log('🔐 SIGNUP SCREEN DEBUG: Platform:', Platform.OS);
           console.log('🔐 SIGNUP SCREEN DEBUG: Error message to store:', t('userExistsInvalidCredentials'));
-          
+
           // Store specific error message for signin page
           if (Platform.OS === 'web') {
             console.log('🔐 SIGNUP SCREEN DEBUG: Web platform - storing error in localStorage');
             localStorage.setItem('signinErrorMessage', t('userExistsInvalidCredentials'));
+            localStorage.setItem('signinEmail', email);
             console.log('🔐 SIGNUP SCREEN DEBUG: Error stored in localStorage, redirecting to /login');
             // Navigate to signin page
             router.replace('/login');
@@ -81,7 +82,7 @@ export default function SignupScreen() {
             // For React Native, we'll pass it as a route param
             router.replace({
               pathname: '/login',
-              params: { errorMessage: t('userExistsInvalidCredentials') }
+              params: { errorMessage: t('userExistsInvalidCredentials'), emailOrPhone: email }
             });
             console.log('🔐 SIGNUP SCREEN DEBUG: router.replace with params called');
           }
@@ -90,12 +91,13 @@ export default function SignupScreen() {
         } else {
           console.log('🔐 SIGNUP SCREEN DEBUG: Different error type, setting generic error message');
           setErrorMessage(errorData.error || t('failedToCreateAccount'));
+          return;
         }
       } else {
         // Success case - call the useAuth signup function for state management
         const success = await signup(email, password);
         console.log('🔐 SIGNUP SCREEN DEBUG: Signup function returned:', success);
-        
+
         if (success) {
           console.log('🔐 SIGNUP SCREEN DEBUG: Signup successful, redirecting to tabs');
           router.replace('/(tabs)');
@@ -107,10 +109,10 @@ export default function SignupScreen() {
     } catch (error: any) {
       console.error('🔐 SIGNUP SCREEN DEBUG: Network or other error:', error);
       setErrorMessage(t('failedToCreateAccount'));
+    } finally {
+      console.log('🔐 SIGNUP SCREEN DEBUG: Setting isLoading to false');
+      setIsLoading(false);
     }
-    
-    console.log('🔐 SIGNUP SCREEN DEBUG: Setting isLoading to false');
-    setIsLoading(false);
   };
 
   // Clear error message when user starts typing


### PR DESCRIPTION
## Summary
- ensure login fields stay interactive by dropping isLoading gating
- reset loading state with finally in login and signup handlers to avoid stale disabled inputs
- prefill login with supplied email or phone and focus password when redirecting after existing-user error

## Testing
- `npm run lint` *(fails: fetch failed)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b1dc397cc88326866412d891c8f779