### PR TITLE
fix: guard window access in auth hook

### DIFF
--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -171,7 +171,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         body: JSON.stringify({
           emailOrPhone: email,
           password: password,
-          clientOrigin: window.location.origin,
+          clientOrigin: Platform.OS === 'web' ? window.location.origin : undefined,
         })
       });
 
@@ -420,7 +420,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       }
 
       try {
-        if (!window.PublicKeyCredential) {
+        if (typeof window === 'undefined' || !window.PublicKeyCredential) {
           return { isAvailable: false, isEnrolled: false, supportedTypes: [] };
         }
 
@@ -700,10 +700,10 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
               'Content-Type': 'application/json',
               Authorization: `Bearer ${process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY}`,
             },
-            body: JSON.stringify({ 
-              authResp, 
+            body: JSON.stringify({
+              authResp,
               expectedChallenge: options.challenge,
-              clientOrigin: window.location.origin,
+              clientOrigin: Platform.OS === 'web' ? window.location.origin : undefined,
             }),
           }
         );


### PR DESCRIPTION
## Summary
- guard `window.location` usage in `useAuth` with `Platform.OS === 'web'`
- handle missing window object before WebAuthn checks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4487bc9e88326b7a7cb28901f0ddc