### PR TITLE
feat(auth): surface login errors

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -74,11 +74,11 @@ export default function LoginScreen() {
 
     setIsLoading(true);
     try {
-      const success = await login(emailOrPhone, password);
-      if (success) {
+      const result = await login(emailOrPhone, password);
+      if (result.success) {
         router.replace('/(tabs)');
       } else {
-        setErrorMessage(t('invalidCredentials'));
+        setErrorMessage(result.error || t('invalidCredentials'));
       }
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
## Summary
- return error details from `useAuth` login
- show detailed error message in login screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: TypeError: fetch failed)*
- `npx tsc --noEmit` *(fails: TS2307: Cannot find module 'npm:@supabase/supabase-js@2.53.0', TS2304: Cannot find name 'Deno')*

------
https://chatgpt.com/codex/tasks/task_e_68b44985ec7c8326bb604315b2953287