### PR TITLE
fix: ensure tab labels visible on mobile web

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -84,6 +84,13 @@ const styles = StyleSheet.create({
     backgroundColor: '#1a1a1a',
     borderTopColor: '#333',
     borderTopWidth: 1,
+    ...Platform.select({
+      web: {
+        paddingBottom: 12,
+        height: 70,
+      },
+      default: {},
+    }),
   },
   tabBarLabel: {
     fontSize: 12,


### PR DESCRIPTION
## Summary
- prevent bottom nav labels from being cropped on mobile web by adding extra bottom padding and height

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: fetch failed during Expo lint)*

------
https://chatgpt.com/codex/tasks/task_e_68b49c4377f88326845bd48baf216c2c