### PR TITLE
fix: ensure fullscreen toggle works

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -55,38 +55,34 @@ export default function HomeScreen() {
   const toggleFullScreen = () => {
     if (Platform.OS !== 'web') return; // Only for web
 
-    const doc = window.document;
-    const docElem = doc.documentElement;
+    const doc: any = window.document;
+    const docElem: any = doc.documentElement || doc.body;
 
-    // Check if currently in fullscreen mode
-    const isFullScreen = doc.fullscreenElement ||
-                         (doc as any).mozFullScreenElement ||
-                         (doc as any).webkitFullscreenElement ||
-                         (doc as any).msFullscreenElement;
+    const isFullScreen =
+      doc.fullscreenElement ||
+      doc.mozFullScreenElement ||
+      doc.webkitFullscreenElement ||
+      doc.msFullscreenElement;
 
     if (!isFullScreen) {
-      // Request fullscreen
-      if (docElem.requestFullscreen) {
-        docElem.requestFullscreen();
-      } else if ((docElem as any).mozRequestFullScreen) { // Firefox
-        (docElem as any).mozRequestFullScreen();
-      } else if ((docElem as any).webkitRequestFullscreen) { // Chrome, Safari and Opera
-        (docElem as any).webkitRequestFullscreen();
-      } else if ((docElem as any).msRequestFullscreen) { // IE/Edge
-        (docElem as any).msRequestFullscreen();
-      }
+      const request =
+        docElem.requestFullscreen ||
+        docElem.mozRequestFullScreen ||
+        docElem.webkitRequestFullscreen ||
+        docElem.msRequestFullscreen;
+
+      request
+        ?.call(docElem)
+        .catch((e: any) => console.warn('Fullscreen request failed', e));
       console.log('Entering fullscreen');
     } else {
-      // Exit fullscreen
-      if (doc.exitFullscreen) {
-        doc.exitFullscreen();
-      } else if ((doc as any).mozCancelFullScreen) { // Firefox
-        (doc as any).mozCancelFullScreen();
-      } else if ((doc as any).webkitExitFullscreen) { // Chrome, Safari and Opera
-        (doc as any).webkitExitFullscreen();
-      } else if ((doc as any).msExitFullscreen) { // IE/Edge
-        (doc as any).msExitFullscreen();
-      }
+      const exit =
+        doc.exitFullscreen ||
+        doc.mozCancelFullScreen ||
+        doc.webkitExitFullscreen ||
+        doc.msExitFullscreen;
+
+      exit?.call(doc);
       console.log('Exiting fullscreen');
     }
   };


### PR DESCRIPTION
## Summary
- improve fullscreen toggle function on web to support vendor-prefixed APIs and handle errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b49f1cd54883268a124b4b676bb074